### PR TITLE
[cherry-pick] Fuse2.9.5 conditionally define closefrom and fix ambigious condition

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -55,6 +55,7 @@ fi
 
 AC_CHECK_FUNCS([fork setxattr fdatasync splice vmsplice utimensat])
 AC_CHECK_FUNCS([posix_fallocate])
+AC_CHECK_FUNCS([closefrom])
 AC_CHECK_MEMBERS([struct stat.st_atim])
 AC_CHECK_MEMBERS([struct stat.st_atimespec])
 

--- a/util/ulockmgr_server.c
+++ b/util/ulockmgr_server.c
@@ -22,6 +22,10 @@
 #include <sys/socket.h>
 #include <sys/wait.h>
 
+#ifdef HAVE_CONFIG_H
+	#include "config.h"
+#endif
+
 struct message {
 	unsigned intr : 1;
 	unsigned nofd : 1;
@@ -124,6 +128,7 @@ static int receive_message(int sock, void *buf, size_t buflen, int *fdp,
 	return res;
 }
 
+#if !defined(HAVE_CLOSEFROM)
 static int closefrom(int minfd)
 {
 	DIR *dir = opendir("/proc/self/fd");
@@ -141,6 +146,7 @@ static int closefrom(int minfd)
 	}
 	return 0;
 }
+#endif
 
 static void send_reply(int cfd, struct message *msg)
 {

--- a/util/ulockmgr_server.c
+++ b/util/ulockmgr_server.c
@@ -96,7 +96,7 @@ static int receive_message(int sock, void *buf, size_t buflen, int *fdp,
 
 	cmsg = CMSG_FIRSTHDR(&msg);
 	if (cmsg) {
-		if (!cmsg->cmsg_type == SCM_RIGHTS) {
+		if (cmsg->cmsg_type != SCM_RIGHTS) {
 			fprintf(stderr,
 				"ulockmgr_server: unknown control message %d\n",
 				cmsg->cmsg_type);


### PR DESCRIPTION
## support libfuse2 in Ubuntu:22.04
JIRA address: https://tachyonnexus.atlassian.net/browse/AC-2076
The code on https://github.com/Alluxio/libfuse/tree/fuse_2_9_5_customize_multi_threads was to install libfuse2 in centos 7. Now I have encountered some problems installing libfuse2 in ubuntu22.04 docker image and have fixed them.
libfuse has fixed the bugs at https://github.com/libfuse/libfuse/tree/fuse_2_9_bugfix, so I cherry-pick their commits.
## cherry-pick
util/ulockmgr_server.c: conditionally define closefrom (fix glibc-2.34+) https://github.com/libfuse/libfuse/pull/619/commits/ae2352bca9b4e607538412da0cc2a9625cd8b692
Fix ambigious condition https://github.com/libfuse/libfuse/commit/c47dde86c0dd3dc6c5cbc7f8df5e77d534c85710
