### PR TITLE
support libfuse2 on ARM

### DIFF
--- a/include/fuse_kernel.h
+++ b/include/fuse_kernel.h
@@ -88,12 +88,16 @@
 #ifndef _LINUX_FUSE_H
 #define _LINUX_FUSE_H
 
-#include <sys/types.h>
+#ifdef __linux__
+#include <linux/types.h>
+#else
+#include <stdint.h>
 #define __u64 uint64_t
 #define __s64 int64_t
 #define __u32 uint32_t
 #define __s32 int32_t
 #define __u16 uint16_t
+#endif
 
 /*
  * Version negotiation:


### PR DESCRIPTION
Use <linux/types.h> for linux and define types used for other operating systems using <stdint.h> types.

I have also tested on mac m1 arm64, which thrown another error:
`conflicting types for 'int64_t' and 'uint64_t'
`
I found this bug can be fixed by [fuse_kernel.h: clean includes · Alluxio/libfuse@914871b](https://github.com/Alluxio/libfuse/commit/914871b20a901e3e1e981c92bc42b1c93b7ab81b)