### PR TITLE
Avoid gcc 11 strncpy warning

### DIFF
--- a/lib/fuse.c
+++ b/lib/fuse.c
@@ -905,7 +905,7 @@ static char *add_name(char **buf, unsigned *bufsize, char *s, const char *name)
 		*bufsize = newbufsize;
 	}
 	s -= len;
-	strncpy(s, name, len);
+	memcpy(s, name, len);
 	s--;
 	*s = '/';
 

--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -260,7 +260,7 @@ char *fuse_add_dirent(char *buf, const char *name, const struct stat *stbuf,
 	dirent->off = off;
 	dirent->namelen = namelen;
 	dirent->type = (stbuf->st_mode & 0170000) >> 12;
-	strncpy(dirent->name, name, namelen);
+	memcpy(dirent->name, name, namelen);
 	if (padlen)
 		memset(buf + entlen, 0, padlen);
 


### PR DESCRIPTION
reference: https://github.com/libfuse/libfuse/pull/447
running `make -j8` have warning:
```
In file included from /usr/include/string.h:535,
                 from fuse.c:23:
In function 'strncpy',
    inlined from 'add_name' at fuse.c:908:2:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:95:10: warning: '__builtin_strncpy' output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
   95 |   return __builtin___strncpy_chk (__dest, __src, __len,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   96 |                                   __glibc_objsize (__dest));
      |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~
fuse.c: In function 'add_name':
fuse.c:884:22: note: length computed here
  884 |         size_t len = strlen(name);
      |                      ^~~~~~~~~~~~
In file included from /usr/include/string.h:535,
                 from fuse_lowlevel.c:22:
In function 'strncpy',
    inlined from 'fuse_add_dirent' at fuse_lowlevel.c:263:2:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:95:10: warning: '__builtin_strncpy' output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
   95 |   return __builtin___strncpy_chk (__dest, __src, __len,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   96 |                                   __glibc_objsize (__dest));
      |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~
fuse_lowlevel.c: In function 'fuse_add_dirent':
fuse_lowlevel.c:253:28: note: length computed here
  253 |         unsigned namelen = strlen(name);
      |                            ^~~~~~~~~~~~
  CC       mount_util.lo
  CC       ulockmgr.lo
```